### PR TITLE
Add demo folder

### DIFF
--- a/demo/demo_manipulate_area_inflation.py
+++ b/demo/demo_manipulate_area_inflation.py
@@ -1,0 +1,61 @@
+##   Copyright (c) Aslak W. Bergersen, Henrik A. Kjeldsberg. All rights reserved.
+##   See LICENSE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even 
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+##      PURPOSE.  See the above copyright notices for more information.
+
+
+# This demo is the equivalent of executing the following in a terminal:
+#  $ morphman-area --ifile C0002/surface/model.vtp --ofile C0002/surface/area_deflated.vtp \
+#       --method area --percentage -20 --region-of-interest first_line --poly-ball-size 250 250 250
+#  $ morphman-area --ifile C0002/surface/model.vtp --ofile C0002/surface/area_inflated.vtp \
+#       --method area --percentage 20 --region-of-interest first_line --poly-ball-size 250 250 250
+
+# and a more detailed explenation could be found here:
+# https://morphman.readthedocs.io/en/latest/manipulate_area.html#inflation-deflation-of-an-arterial-segment
+
+from morphman import manipulate_area, main_area, read_command_line_area
+from os import path
+from get_test_data import download_case
+
+# Set absolute path to the demo folder
+absolute_path = path.dirname(path.abspath(__file__))
+
+# Set input and output paths
+case = "C0002"
+input_filepath = path.join(absolute_path, case, "surface", "model.vtp")
+output_filepath = path.join(absolute_path, case, "surface", "area_deflated.vtp")
+
+# Download case from the Aneurisk web for this demo
+if not path.exists(path.join(input_filepath)):
+    download_case(case)
+
+# Get default values for manipulate_area
+default_values = read_command_line_area(input_filepath, output_filepath)
+
+# Set region of interest
+default_values["region_of_interest"] = "first_line"
+
+# Method for changing the area
+default_values["method"] = "area"
+
+# Method spesific parameters - decrease cross-section area
+default_values["percentage"] = -20
+
+# Parameters for reconstructing the surface
+default_values["poly_ball_size"] = [250, 250, 250]
+
+# Run manipulation
+manipulate_area(**default_values)
+
+
+### Increase cross-section area
+# Method spesific parameters
+default_values["percentage"] = 20
+
+# Set new output path
+output_filepath = path.join(absolute_path, case, "surface", "area_inflated.vtp")
+
+# Run manipulation
+manipulate_area(**default_values)

--- a/demo/demo_manipulate_area_stenosis.py
+++ b/demo/demo_manipulate_area_stenosis.py
@@ -8,7 +8,7 @@
 
 # This demo is the equivalent of executing the following in a terminal:
 #  $ morphman-area --ifile C0002/surface/model.vtp --ofile C0002/surface/stenosis.vtp \
-#       --method stenosis --size 4 --percentage 50 --region-of-interest commandline \
+#       --method stenosis --stenosis-length 4 --percentage 50 --region-of-interest commandline \
 #       --region-points 28.7 18.4 39.5 --poly-ball-size 250 250 250
 #  $ morphman-area --ifile C0002/surface/stenosis.vtp --ofile C0002/surface/stenosis_removed.vtp \
 #       --method stenosis --region-of-interest commandline \
@@ -44,7 +44,7 @@ default_values["region_points"] = [28.7, 18.4, 39.5]
 default_values["method"] = "stenosis"
 
 # Method spesific parameters - create a stenosis
-default_values["size"] = 4.0
+default_values["stenosis_length"] = 4.0
 default_values["percentage"] = 50
 
 # Parameters for reconstructing the surface

--- a/demo/demo_manipulate_area_stenosis.py
+++ b/demo/demo_manipulate_area_stenosis.py
@@ -1,0 +1,65 @@
+##   Copyright (c) Aslak W. Bergersen, Henrik A. Kjeldsberg. All rights reserved.
+##   See LICENSE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even 
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+##      PURPOSE.  See the above copyright notices for more information.
+
+
+# This demo is the equivalent of executing the following in a terminal:
+#  $ morphman-area --ifile C0002/surface/model.vtp --ofile C0002/surface/stenosis.vtp \
+#       --method stenosis --size 4 --percentage 50 --region-of-interest commandline \
+#       --region-points 28.7 18.4 39.5 --poly-ball-size 250 250 250
+#  $ morphman-area --ifile C0002/surface/stenosis.vtp --ofile C0002/surface/stenosis_removed.vtp \
+#       --method stenosis --region-of-interest commandline \
+#       --region-points 30.1 18.5 34.6 27.1 12.7 38.2 --poly-ball-size 250 250 250
+#
+# and a more detailed explenation could be found here:
+# https://morphman.readthedocs.io/en/latest/manipulate_area.html#create-remove-a-stenosis
+
+from morphman import manipulate_area, main_area, read_command_line_area
+from os import path
+from get_test_data import download_case
+
+# Set absolute path to the demo folder
+absolute_path = path.dirname(path.abspath(__file__))
+
+# Set input and output paths
+case = "C0002"
+input_filepath = path.join(absolute_path, case, "surface", "model.vtp")
+output_filepath = path.join(absolute_path, case, "surface", "stenosis.vtp")
+
+# Download case from the Aneurisk web for this demo
+if not path.exists(path.join(input_filepath)):
+    download_case(case)
+
+# Get default values for manipulate_area
+default_values = read_command_line_area(input_filepath, output_filepath)
+
+# Set region of interest
+default_values["region_of_interest"] = "commandline"
+default_values["region_points"] = [28.7, 18.4, 39.5]
+
+# Method for changing the area
+default_values["method"] = "stenosis"
+
+# Method spesific parameters - create a stenosis
+default_values["size"] = 4.0
+default_values["percentage"] = 50
+
+# Parameters for reconstructing the surface
+default_values["poly_ball_size"] = [250, 250, 250]
+
+# Run manipulation
+manipulate_area(**default_values)
+
+
+### Decrease cross-section area ratio
+# Method spesific parameters
+default_values["region_points"] = [30.1, 18.5, 34.6, 27.1, 12.7, 38.2]
+
+# Set new output path
+output_filepath = path.join(absolute_path, case, "surface", "stenosis_removed.vtp")
+
+# Run manipulation
+manipulate_area(**default_values)

--- a/demo/demo_manipulate_area_variation.py
+++ b/demo/demo_manipulate_area_variation.py
@@ -1,0 +1,61 @@
+##   Copyright (c) Aslak W. Bergersen, Henrik A. Kjeldsberg. All rights reserved.
+##   See LICENSE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even 
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+##      PURPOSE.  See the above copyright notices for more information.
+
+
+# This demo is the equivalent of executing the following in a terminal:
+#  $ morphman-area --ifile C0002/surface/model.vtp --ofile C0002/surface/increased_variation.vtp \
+#        --method variation --ratio 4.0 --region-of-interest first_line --poly-ball-size 250 250 250
+#  $ morphman-area --ifile C0002/surface/model.vtp --ofile C0002/surface/decreased_variation.vtp \
+#        --method variation --ratio 0.5 --region-of-interest first_line --poly-ball-size 250 250 250
+#
+# and a more detailed explenation could be found here:
+# https://morphman.readthedocs.io/en/latest/manipulate_area.html#area-variations
+
+from morphman import manipulate_area, main_area, read_command_line_area
+from os import path
+from get_test_data import download_case
+
+# Set absolute path to the demo folder
+absolute_path = path.dirname(path.abspath(__file__))
+
+# Set input and output paths
+case = "C0002"
+input_filepath = path.join(absolute_path, case, "surface", "model.vtp")
+output_filepath = path.join(absolute_path, case, "surface", "increased_variation.vtp")
+
+# Download case from the Aneurisk web for this demo
+if not path.exists(path.join(input_filepath)):
+    download_case(case)
+
+# Get default values for manipulate_area
+default_values = read_command_line_area(input_filepath, output_filepath)
+
+# Set region of interest
+default_values["region_of_interest"] = "first_line"
+
+# Method for changing the area
+default_values["method"] = "variation"
+
+# Method spesific parameters - increase cross-section area ratio
+default_values["ratio"] = 4.0
+
+# Parameters for reconstructing the surface
+default_values["poly_ball_size"] = [250, 250, 250]
+
+# Run manipulation
+manipulate_area(**default_values)
+
+
+### Decrease cross-section area ratio
+# Method spesific parameters
+default_values["ratio"] = 1.0
+
+# Set new output path
+output_filepath = path.join(absolute_path, case, "surface", "decreased_variation.vtp")
+
+# Run manipulation
+manipulate_area(**default_values)

--- a/demo/demo_manipulate_bend.py
+++ b/demo/demo_manipulate_bend.py
@@ -1,0 +1,71 @@
+##   Copyright (c) Aslak W. Bergersen, Henrik A. Kjeldsberg. All rights reserved.
+##   See LICENSE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even 
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+##      PURPOSE.  See the above copyright notices for more information.
+
+
+# This demo is the equivalent of executing the following in a terminal:
+#  $ morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_vertical_plus.vtp \
+#       --alpha 0.4 --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 \
+#       --poly-ball-size 250 250 250
+#  $ morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_vertical_minus.vtp \
+#       --alpha -0.4 --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 \
+#       --poly-ball-size 250 250 250
+#
+#  $ morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_horizontal_plus.vtp \
+#       --beta 0.4 --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 \
+#       --poly-ball-size 250 250 250
+#  $ morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_horizontal_minus.vtp \
+#       --beta -0.4 --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 \
+#       --poly-ball-size 250 250 250
+#
+#  $ morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_plus.vtp \
+#       --alpha 0.4 --beta 0.4 --region-of-interest commandline \
+#       --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
+#  $ morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_minus.vtp \
+#       --alpha -0.4 --beta -0.4 --region-of-interest commandline \
+#       --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
+#
+# and a more detailed explenation could be found here:
+# https://morphman.readthedocs.io/en/latest/manipulate_bend.html#tutorial-manipulate-bend
+
+from morphman import manipulate_bend, main_bend, read_command_line_bend
+from os import path
+from get_test_data import download_case
+
+# Set absolute path to the demo folder
+absolute_path = path.dirname(path.abspath(__file__))
+
+# Set input and output paths
+case = "C0005"
+input_filepath = path.join(absolute_path, case, "surface", "model.vtp")
+output_filepath = path.join(absolute_path, case, "surface", "%s.vtp")
+
+# Download case from the Aneurisk web for this demo
+if not path.exists(path.join(input_filepath)):
+    download_case(case)
+
+# Get default values for manipulate_bend
+default_values = read_command_line_bend(input_filepath, output_filepath)
+
+# Set region of interest
+default_values["region_of_interest"] = "commandline"
+default_values["region_points"] = [49.8, 49.7, 36.6, 53.1, 41.8, 38.3]
+
+# Method spesific parameters
+beta = [0, 0, 0.4, -0.4, 0.4, -0.4]
+alpha = [0.4, -0.4, 0, 0, 0.4, -0.4]
+names = ["bend_vertical_plus", "bend_vertical_minus", "bend_horizonal_plus",
+         "bend_horizontal_plus", "bend_plus", "bend_minus"]
+
+# Parameters for reconstructing the surface
+default_values["poly_ball_size"] = [250, 250, 250]
+
+# Run manipulation
+for b, a, n in zip(beta, alpha, names):
+    default_values["beta"] = b
+    default_values["alpha"] = a
+    default_values["output_filepath"] = n
+    manipulate_bend(**default_values)

--- a/demo/demo_manipulate_bend.py
+++ b/demo/demo_manipulate_bend.py
@@ -67,5 +67,5 @@ default_values["poly_ball_size"] = [250, 250, 250]
 for b, a, n in zip(beta, alpha, names):
     default_values["beta"] = b
     default_values["alpha"] = a
-    default_values["output_filepath"] = n
+    default_values["output_filepath"] = n + ".vtp"
     manipulate_bend(**default_values)

--- a/demo/demo_manipulate_bifurcation.py
+++ b/demo/demo_manipulate_bifurcation.py
@@ -88,7 +88,7 @@ default_values["input_filepath"] = path.join(absolute_path, case, "surface", "mo
 default_values["output_filepath"] = path.join(absolute_path, case, "surface", "rotate_plus.vtp")
 
 # Download case from the Aneurisk web for this demo
-if not path.exists(path.join(input_filepath)):
+if not path.exists(path.join(default_values["input_filepath"])):
     download_case(case)
 
 # Set region of interest

--- a/demo/demo_manipulate_bifurcation.py
+++ b/demo/demo_manipulate_bifurcation.py
@@ -1,0 +1,106 @@
+##   Copyright (c) Aslak W. Bergersen, Henrik A. Kjeldsberg. All rights reserved.
+##   See LICENSE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even 
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+##      PURPOSE.  See the above copyright notices for more information.
+
+
+# This demo is the equivalent of executing the following in a terminal:
+#  $ morphman-bifurcation --ifile C0005/surface/model.vtp --ofile C0005/surface/rotate_plus.vtp \
+#       --angle 20 --region-of-interest commandline --region-points 43.2 70.5 26.4 84.4 60.6 50.6 \
+#       --poly-ball-size 250 250 250
+#  $ morphman-bifurcation --ifile C0005/surface/model.vtp --ofile C0005/surface/rotate_minus.vtp \
+#       --angle -20 --region-of-interest commandline --region-points 43.2 70.5 26.4 84.4 60.6 50.6 \
+#        --poly-ball-size 250 250 250
+#
+#  $ morphman-bifurcation --ifile C0005/surface/model.vtp --ofile C0005/surface/rotate_no_notch.vtp \
+#       --angle -20 --bif True --lower True --region-of-interest commandline \
+#       --region-points 43.2 70.5 26.4 84.4 60.6 50.6 --poly-ball-size 250 250 250
+#
+#  $ morphman-bifurcation --ifile C0066/surface/model.vtp --ofile C0066/surface/removed_aneurysm.vtp \
+#       --keep-fixed-1 True --keep-fixed-2 True --bif True --lower True --angle 0 \
+#       --region-of-interest commandline --region-points 31.37 60.65 25.21 67.81 43.08 41.24 \
+#       --poly-ball-size 250 250 250
+#
+# and a more detailed explenation could be found here:
+# https://morphman.readthedocs.io/en/latest/manipulate_bifurcation.html#tutorial-manipulate-bifurcation
+
+from morphman import manipulate_bifurcation, main_bifurcation, read_command_line_bifurcation
+from os import path
+from get_test_data import download_case
+
+# Set absolute path to the demo folder
+absolute_path = path.dirname(path.abspath(__file__))
+
+# Set input and output paths
+case = "C0005"
+input_filepath = path.join(absolute_path, case, "surface", "model.vtp")
+output_filepath = path.join(absolute_path, case, "surface", "rotate_plus.vtp")
+
+# Download case from the Aneurisk web for this demo
+if not path.exists(path.join(input_filepath)):
+    download_case(case)
+
+# Get default values for manipulate_bifurcation
+default_values = read_command_line_bifurcation(input_filepath, output_filepath)
+
+# Set region of interest
+default_values["region_of_interest"] = "commandline"
+default_values["region_points"] = [43.2, 70.5, 26.4, 84.4, 60.6, 50.6]
+
+# Method spesific parameters - rotate the daughter branches together
+default_values["angle"] = 20
+
+# Parameters for reconstructing the surface
+default_values["poly_ball_size"] = [250, 250, 250]
+
+# Run manipulation
+manipulate_bifurcation(**default_values)
+
+
+### Negative angle
+# Method spesific parameters - rotate the daughter branches appart
+default_values["angle"] = -20
+
+# Set new output path
+output_filepath = path.join(absolute_path, case, "surface", "rotate_minus.vtp")
+
+# Run manipulation
+manipulate_bifurcation(**default_values)
+
+
+### No-noch
+# Method spesific parameters - improved rebuilding of the bifurcation
+default_values["bif"] = True
+default_values["lower"] = True
+
+# Set new output path
+output_filepath = path.join(absolute_path, case, "surface", "no_noch.vtp")
+
+# Run manipulation
+manipulate_bifurcation(**default_values)
+
+
+### Remove an aneurysm
+case = "C0066"
+default_values["input_filepath"] = path.join(absolute_path, case, "surface", "model.vtp")
+default_values["output_filepath"] = path.join(absolute_path, case, "surface", "rotate_plus.vtp")
+
+# Download case from the Aneurisk web for this demo
+if not path.exists(path.join(input_filepath)):
+    download_case(case)
+
+# Set region of interest
+default_values["region_of_interest"] = "commandline"
+default_values["region_points"] = [31.37, 60.65, 25.21, 67.81, 43.08, 41.24]
+
+# Method spesific parameters
+default_values["keep_fixed_1"] = True
+default_values["keep_fixed_2"] = True
+default_values["bif"] = True
+default_values["lower"] = True
+default_values["angle"] = 0
+
+# Run manipulation
+manipulate_bifurcation(**default_values)

--- a/demo/demo_manipulate_curvature.py
+++ b/demo/demo_manipulate_curvature.py
@@ -41,7 +41,7 @@ default_values = read_command_line_curvature(input_filepath, output_filepath)
 default_values["region_of_interest"] = "first_line"
 
 # Method spesific parameters - reduce the curvature
-dafault_values["smooth_line"] = True
+default_values["smooth_line"] = True
 default_values["iterations"] = 100
 default_values["smooth_factor_line"] = 1.8
 

--- a/demo/demo_manipulate_curvature.py
+++ b/demo/demo_manipulate_curvature.py
@@ -1,0 +1,62 @@
+##   Copyright (c) Aslak W. Bergersen, Henrik A. Kjeldsberg. All rights reserved.
+##   See LICENSE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even 
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+##      PURPOSE.  See the above copyright notices for more information.
+
+
+# This demo is the equivalent of executing the following in a terminal:
+#  $ morphman-curvature --ifile C0005/surface/model.vtp --ofile C0005/surface/model_curvature_decreased.vtp \
+#       --smooth-line True --iterations 100 --smooth-factor-line 1.8 --region-of-interest first_line \
+#       --poly-ball-size 250 250 250
+#
+#  $ morphman-curvature --ifile C0005/surface/model.vtp --ofile C0005/surface/model_curvature_increased.vtp \
+#       --smooth-line False --iterations 100 --smooth-factor-line 1.8 --region-of-interest first_line \
+#       --poly-ball-size 250 250 250
+#
+# and a more detailed explenation could be found here:
+# https://morphman.readthedocs.io/en/latest/manipulate_curvature.html#tutorial-manipulate-curvature
+
+from morphman import manipulate_curvature, main_curvature, read_command_line_curvature
+from os import path
+from get_test_data import download_case
+
+# Set absolute path to the demo folder
+absolute_path = path.dirname(path.abspath(__file__))
+
+# Set input and output paths
+case = "C0005"
+input_filepath = path.join(absolute_path, case, "surface", "model.vtp")
+output_filepath = path.join(absolute_path, case, "surface", "curvature_plus.vtp")
+
+# Download case from the Aneurisk web for this demo
+if not path.exists(path.join(input_filepath)):
+    download_case(case)
+
+# Get default values for manipulate_curvature
+default_values = read_command_line_curvature(input_filepath, output_filepath)
+
+# Set region of interest
+default_values["region_of_interest"] = "first_line"
+
+# Method spesific parameters - reduce the curvature
+dafault_values["smooth_line"] = True
+default_values["iterations"] = 100
+default_values["smooth_factor_line"] = 1.8
+
+# Parameters for reconstructing the surface
+default_values["poly_ball_size"] = [250, 250, 250]
+
+# Run manipulation
+manipulate_curvature(**default_values)
+
+
+### Increase the curvature
+# Method specific paramters
+default_values["smooth_line"] = False
+
+# Set new output path
+output_filepath = path.join(absolute_path, case, "surface", "no_noch.vtp")
+
+manipulate_curvature(**default_values)

--- a/demo/get_test_data.py
+++ b/demo/get_test_data.py
@@ -1,0 +1,42 @@
+##   Copyright (c) Aslak W. Bergersen, Henrik A. Kjeldsberg. All rights reserved.
+##   See LICENSE file for details.
+
+##      This software is distributed WITHOUT ANY WARRANTY; without even 
+##      the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+##      PURPOSE.  See the above copyright notices for more information.
+
+from os import system, path
+from sys import platform
+
+def download_case(case):
+    abs_path = path.dirname(path.abspath(__file__))
+    output_file = path.join(abs_path, "{}_models.tar.gz".format(case))
+    adress = "http://ecm2.mathcs.emory.edu/aneuriskdata/download/{}/{}_models.tar.gz".format(case, case)
+
+    try:
+        if platform == "darwin":
+            system("curl {} --output {}".format(adress, output_file))
+            system("tar -zxvf {}".format(output_file))
+            system("rm {}".format(output_file))
+
+        elif platform == "linux" or platform == "linux2":
+            system("wget {}".format(adress))
+            system("tar -zxvf {}".format(output_file))
+            system("rm {}".format(output_file))
+
+        elif platform == "win32":
+            system("bitsadmin /transfer download_model /download /priority high {} {}".format(adress, output_file))
+            system("tar -zxvf {}".format(output_file))
+            system("del /f {}".format(output_file))
+
+    except:
+        raise RuntimeError("Problem downloading the testdata, please do it manually from " \
+                           + adress + " and extract the compressed tarball in the" \
+                           + " test folder")
+
+if __name__ == "__main__":
+    download_case("C0001")
+    download_case("C0002")
+    download_case("C0003")
+    download_case("C0004")
+    download_case("C0005")

--- a/docs/source/manipulate_area.rst
+++ b/docs/source/manipulate_area.rst
@@ -8,7 +8,9 @@ Tutorial: Manipulate area
 
 Manipulation of the cross-sectional area is performed by running ``morphman-area`` in the terminal, followed by the
 respective command line arguments. Alternatively, you can execute the Python script directly,
-located in the ``morphman`` subfolder, by typing ``python manipulate_area.py``.
+located in the ``morphman`` subfolder, by typing ``python manipulate_area.py``. We have also created a
+demo folder where we show how to run this tutorial from a python script, please checkout the code from github to
+run the demos.
 
 In this tutorial, we are using the model with
 `ID C0002 <http://ecm2.mathcs.emory.edu/aneuriskdata/download/C0002/C0002_models.tar.gz>`_
@@ -59,7 +61,7 @@ obtained by executing the following commands from the command line::
 
 for the model with increased cross-sectional area variation, and::
 
-    morphman-area --ifile C0002/surface/model.vtp --ofile C0002/surface/decreased_variation.vtp --method variation --ratio 0.5 --region-of-interest first_line --poly-ball-size 250 250 250
+    morphman-area --ifile C0002/surface/model.vtp --ofile C0002/surface/decreased_variation.vtp --method variation --ratio 1.0 --region-of-interest first_line --poly-ball-size 250 250 250
 
 for the model with decreased cross-sectional area variation.
 
@@ -94,7 +96,7 @@ sections with high curvature, like the internal carotid artery, is unproblematic
 
 To recreate the above output, execute the following from the commandline::
 
-    morphman-area --ifile C0002/surface/model.vtp  --ofile C0002/surface/stenosis.vtp --method stenosis --size 4 --percentage 50 --region-of-interest commandline --region-points 28.7 18.4 39.5 --poly-ball-size 250 250 250
+    morphman-area --ifile C0002/surface/model.vtp --ofile C0002/surface/stenosis.vtp --method stenosis --size 4 --percentage 50 --region-of-interest commandline --region-points 28.7 18.4 39.5 --poly-ball-size 250 250 250
 
 Remove a stenosis
 ~~~~~~~~~~~~~~~~~
@@ -111,7 +113,7 @@ right, the comparison between the original model and the 'healed' surface.
     
 To reproduce the above result, execute the following command::
 
-    morphman-area --ifile C0002/surface/stenosis.vtp  --ofile C0002/surface/stenosis_removed.vtp --method stenosis --size 4 --percentage 50 --region-of-interest commandline --region-points 30.1 18.5 34.6 27.1 12.7 38.2 --poly-ball-size 250 250 250
+    morphman-area --ifile C0002/surface/stenosis.vtp --ofile C0002/surface/stenosis_removed.vtp --method stenosis --region-of-interest commandline --region-points 30.1 18.5 34.6 27.1 12.7 38.2 --poly-ball-size 250 250 250
 
 Inflation / deflation of an arterial segment
 ============================================

--- a/docs/source/manipulate_bend.rst
+++ b/docs/source/manipulate_bend.rst
@@ -7,9 +7,11 @@ Tutorial: Manipulate bend
 =========================
 
 The goal of ``morphman-bend``, is to alter one specific bend in the
-vasculature, like shown in Figure 1. This can be performed by running ``morphman-bend`` in the terminal, followed by the
-respective command line arguments. Alternatively, you can execute the Python script directly,
-located in the ``morphman`` subfolder, by typing ``python manipulate_bend.py``.
+vasculature, like shown in Figure 1. This can be performed by running ``morphman-bend`` in the terminal,
+followed by the respective command line arguments. Alternatively, you can execute the Python script directly,
+located in the ``morphman`` subfolder, by typing ``python manipulate_bend.py``. We have also created a 
+demo folder where we show how to run this tutorial from a python script, please checkout the code from github to
+run the demos.
 
 .. figure:: Bend_moving.png
 
@@ -41,16 +43,16 @@ Figure 2 depicts an example of modifying the input surface in the :math:`\alpha`
 
 To recreate the surfaces shown in Figure 2, run the following two commands::
 
-    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_vertical_plus.vtp --alpha 0.4  --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
+    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_vertical_plus.vtp --alpha 0.4 --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
 
-    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_vertical_minus.vtp --alpha -0.4  --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
+    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_vertical_minus.vtp --alpha -0.4 --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
 
 Shown in Figure 3 is the output of changing the surface in the
 :math:`\beta` ('horizontal') direction only. This can be reproduced by running the following two commands::
 
-    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_horizontal_plus.vtp --beta 0.4  --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
+    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_horizontal_plus.vtp --beta 0.4 --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
 
-    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_horizontal_minus.vtp --beta -0.4  --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
+    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_horizontal_minus.vtp --beta -0.4 --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
 
 .. figure:: bend_beta_variation.png
 
@@ -60,9 +62,9 @@ Finally, we can extend the movement to both directions by setting both :math:`\a
 An example, where the bend has been moved in both directions, is illustrated in Figure 4.
 In order to reproduce this result, you can run the following commands::
 
-    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_plus.vtp --alpha 0.4 --beta 0.4  --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
+    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_plus.vtp --alpha 0.4 --beta 0.4 --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
 
-    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_minus.vtp --alpha -0.4 --beta -0.4  --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
+    morphman-bend --ifile C0005/surface/model.vtp --ofile C0005/surface/bend_minus.vtp --alpha -0.4 --beta -0.4 --region-of-interest commandline --region-points 49.8 49.7 36.6 53.1 41.8 38.3 --poly-ball-size 250 250 250
 
 .. figure:: bend_alpha_beta_variation.png
 

--- a/docs/source/manipulate_bifurcation.rst
+++ b/docs/source/manipulate_bifurcation.rst
@@ -23,8 +23,9 @@ from the Aneurisk database. For the commands below we assume that there
 is a file `./C0005/surface/model.vtp`, relative to where you execute the command.
 Performing the manipulation can be achieved by running ``morphman-bifurcation`` in the terminal, followed by the
 respective command line arguments. Alternatively, you can execute the Python script directly,
-located in the ``morphman`` subfolder, by typing ``python manipulate_bifurcation.py``.
-
+located in the ``morphman`` subfolder, by typing ``python manipulate_bifurcation.py``. We have also created a 
+demo folder where we show how to run this tutorial from a python script, please checkout the code from github to
+run the demos.
 
 Shown in Figure 2 is the result of rotating the two daughter branches with both
 a positive and negative angle.
@@ -47,7 +48,7 @@ which will output a smoother bifurcation, as shown on the right side in Figure 3
 The results shown in Figure 3 can reproduced by
 running the command::
 
-    morphman-bifurcation --ifile C0005/surface/model.vtp --ofile C0005/surface/rotate_no_notch.vtp --angle -20 --bif True --lower True  --region-of-interest commandline --region-points 43.2 70.5 26.4 84.4 60.6 50.6 --poly-ball-size 250 250 250
+    morphman-bifurcation --ifile C0005/surface/model.vtp --ofile C0005/surface/rotate_no_notch.vtp --angle -20 --bif True --lower True --region-of-interest commandline --region-points 43.2 70.5 26.4 84.4 60.6 50.6 --poly-ball-size 250 250 250
 
 Using both flags have proven to give an improved surface,
 and when used for computational fluid dynamics, a more physiological plausible wall shear stress [2]_.

--- a/docs/source/manipulate_curvature.rst
+++ b/docs/source/manipulate_curvature.rst
@@ -10,7 +10,9 @@ The goal of ``manipulate_curvature.py`` is to increase or decrease the
 total curvature/torsion in a vascular segment, see Figure 1 for an example.
 The manipulation can be achieved by running ``morphman-curvature`` in the terminal, followed by the
 respective command line arguments. Alternatively, you can execute the Python script directly,
-located in the ``morphman`` subfolder, by typing ``python manipulate_curvature.py``.
+located in the ``morphman`` subfolder, by typing ``python manipulate_curvature.py``. We have also created a 
+demo folder where we show how to run this tutorial from a python script, please checkout the code from github to
+run the demos.
 
 .. figure:: Curvature.png
   
@@ -44,11 +46,11 @@ see the right most surface in Figure 2.
 
 To reproduce the surface model with decreased total curvature shown on the left in Figure 2, run::
 
-    morphman-curvature --ifile C0005/surface/model.vtp --ofile C0005/surface/model_curvature_decreased.vtp --smooth-line True --iterations 100 --smooth-factor-line 1.8  --region-of-interest first_line --poly-ball-size 250 250 250
+    morphman-curvature --ifile C0005/surface/model.vtp --ofile C0005/surface/curvature_decreased.vtp --smooth-line True --iterations 100 --smooth-factor-line 1.8 --region-of-interest first_line --poly-ball-size 250 250 250
 
 To reproduce the surface model with increased total curvature shown on the right in Figure 2, run::
 
-    morphman-curvature --ifile C0005/surface/model.vtp --ofile C0005/surface/model_curvature_increased.vtp --smooth-line False --iterations 100 --smooth-factor-line 1.8  --region-of-interest first_line --poly-ball-size 250 250 250
+    morphman-curvature --ifile C0005/surface/model.vtp --ofile C0005/surface/curvature_increased.vtp --smooth-line False --iterations 100 --smooth-factor-line 1.8 --region-of-interest first_line --poly-ball-size 250 250 250
 
 As shown in the command above, increased total curvature is achieved by setting the command line argument ``--smooth-line`` to **False**.
 

--- a/morphman/__init__.py
+++ b/morphman/__init__.py
@@ -1,5 +1,5 @@
 # Main features
-from .manipulate_area import manipulate_area, main_area
-from .manipulate_bifurcation import manipulate_bifurcation, main_bifurcation
-from .manipulate_bend import manipulate_bend, main_bend
-from .manipulate_curvature import manipulate_curvature, main_curvature
+from .manipulate_area import *
+from .manipulate_bifurcation import *
+from .manipulate_bend import *
+from .manipulate_curvature import *

--- a/morphman/common/argparse_common.py
+++ b/morphman/common/argparse_common.py
@@ -23,9 +23,13 @@ def str2bool(boolean):
         raise ValueError('Boolean value expected.')
 
 
-def add_common_arguments(parser):
+def add_common_arguments(parser, required=True):
     # Required arguments
-    required = parser.add_argument_group('Required arguments')
+    if required:
+        required = parser.add_argument_group('Required arguments')
+    else:
+        required = parser
+
     required.add_argument('-i', '--ifile', type=str, default=None, required=True,
                           help="Path to the surface model")
     required.add_argument("-o", "--ofile", type=str, default=None, required=True,

--- a/morphman/manipulate_area.py
+++ b/morphman/manipulate_area.py
@@ -349,7 +349,7 @@ def read_command_line_area(input_path=None, output_path=None):
                              " and instead approximated to obtain the target ratio")
 
     # "Stenosis" argument
-    parser.add_argument("--size", type=float, default=2.0, metavar="length",
+    parser.add_argument("-l", "--stenosis-length", type=float, default=2.0,
                         help="For method=stenosis: The length of the area " +
                              " affected by a stenosis relative to the minimal inscribed" +
                              " sphere radius of the selected point. Default is 2.0.")
@@ -387,7 +387,7 @@ def read_command_line_area(input_path=None, output_path=None):
                 smooth_factor=args.smooth_factor, beta=args.beta,
                 region_of_interest=args.region_of_interest,
                 region_points=args.region_points, ratio=args.ratio,
-                stenosis_length=args.size,
+                stenosis_length=args.stenosis_length,
                 percentage=args.percentage, output_filepath=args.ofile,
                 poly_ball_size=args.poly_ball_size, no_smooth=args.no_smooth,
                 no_smooth_point=args.no_smooth_point, resampling_step=args.resampling_step)

--- a/morphman/manipulate_area.py
+++ b/morphman/manipulate_area.py
@@ -278,9 +278,15 @@ def change_area(voronoi, line_to_change, method, beta, ratio, percentage,
     return new_voronoi
 
 
-def read_command_line():
+def read_command_line_area(input_path=None, output_path=None):
     """
-    Read arguments from commandline
+    Read arguments from commandline and return all values in a dictionary.
+    If input_path and output_path are not None, then do not parse command line, but
+    only return default values.
+
+    Args:
+        input_path (str): Input file path, positional argument with default None.
+        output_path (str): Output file path, positional argument with default None.
     """
     # Description of the script
     description = "Manipulates the area of a tubular geometry. The script changes the area" + \
@@ -291,7 +297,8 @@ def read_command_line():
     parser = ArgumentParser(description=description, formatter_class=RawDescriptionHelpFormatter)
 
     # Add common arguments
-    add_common_arguments(parser)
+    required = not (input_path is not None and output_path is not None)
+    add_common_arguments(parser, required=required)
 
     # Mode / method for manipulation
     parser.add_argument("-m", "--method", type=str, default="variation",
@@ -353,8 +360,11 @@ def read_command_line():
                              " area of the geometry is increase/decreased overall or only" +
                              " stenosis")
 
-    # Parse
-    args = parser.parse_args()
+    # Parse paths to get default values
+    if required:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(["-i" + input_path, "-o" + output_path])
 
     if args.method == "stenosis" and args.region_of_interest == "first_line":
         raise ValueError("Can not set region of interest to 'first_line' when creating or" +

--- a/morphman/manipulate_bend.py
+++ b/morphman/manipulate_bend.py
@@ -414,9 +414,15 @@ def move_voronoi_vertically(voronoi_clipped, centerline_clipped, id1_0, clip_id,
     return new_dataset
 
 
-def read_command_line():
+def read_command_line_bend(input_path=None, output_path=None):
     """
-    Read arguments from commandline
+    Read arguments from commandline and return all values in a dictionary.
+    If input_path and output_path are not None, then do not parse command line, but
+    only return default values.
+
+    Args:
+        input_path (str): Input file path, positional argument with default None.
+        output_path (str): Output file path, positional argument with default None.
     """
     # Description of the script
     description = "Moves a selected part of a tubular geometry, " + \
@@ -427,7 +433,8 @@ def read_command_line():
     parser = ArgumentParser(description=description, formatter_class=RawDescriptionHelpFormatter)
 
     # Add common arguments
-    add_common_arguments(parser)
+    required = not (input_path is not None and output_path is not None)
+    add_common_arguments(parser, required=required)
 
     # Set region of interest:
     parser.add_argument("-r", "--region-of-interest", type=str, default="manual",
@@ -457,7 +464,10 @@ def read_command_line():
                              "ranging from -1.0 to 1.0, defining the magnitude " +
                              "of stretching or compression of the tubular structure.")
     # Output file argument
-    args = parser.parse_args()
+    if required:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(["-i" + input_path, "-o" + output_path])
 
     if args.no_smooth_point is not None and len(args.no_smooth_point):
         if len(args.no_smooth_point) % 3 != 0:

--- a/morphman/manipulate_bifurcation.py
+++ b/morphman/manipulate_bifurcation.py
@@ -550,18 +550,23 @@ def merge_cl(centerline, end_point, div_point):
 
     return merge
 
-
-def read_command_line():
+def read_command_line_bifurcation(input_path=None, output_path=None):
     """
-    Read arguments from commandline
-    """
+    Read arguments from commandline and return all values in a dictionary.
+    If input_path and output_path are not None, then do not parse command line, but
+    only return default values.
 
+    Args:
+        input_path (str): Input file path, positional argument with default None.
+        output_path (str): Output file path, positional argument with default None.
+    """
     description = "Removes the bifurcation (possibly with an aneurysm), after which the" + \
                   " daughter branches can be rotated."
     parser = ArgumentParser(description=description, formatter_class=RawDescriptionHelpFormatter)
 
     # Add common arguments
-    add_common_arguments(parser)
+    required = not (input_path is not None and output_path is not None)
+    add_common_arguments(parser, required=required)
 
     # Set region of interest:
     parser.add_argument("-r", "--region-of-interest", type=str, default="manual",
@@ -601,7 +606,11 @@ def read_command_line():
     parser.add_argument("--cylinder-factor", type=float, default=7.0,
                         help="Factor for choosing the smaller cylinder")
 
-    args = parser.parse_args()
+    # Parse paths to get default values
+    if required:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(["-i" + input_path, "-o" + output_path])
     ang_ = 0 if args.angle == 0 else args.angle * math.pi / 180  # Convert from deg to rad
 
     return dict(input_filepath=args.ifile, smooth=args.smooth, output_filepath=args.ofile,

--- a/morphman/manipulate_curvature.py
+++ b/morphman/manipulate_curvature.py
@@ -285,9 +285,15 @@ def move_all_centerlines(old_cl, new_cl, diverging_id, diverging_centerlines, sm
     return centerline
 
 
-def read_command_line():
+def read_command_line_curvature(input_path=None, output_path=None):
     """
-    Read arguments from commandline
+    Read arguments from commandline and return all values in a dictionary.
+    If input_path and output_path are not None, then do not parse command line, but
+    only return default values.
+
+    Args:
+        input_path (str): Input file path, positional argument with default None.
+        output_path (str): Output file path, positional argument with default None.
     """
     # Description of the script
     description = "Manipulates a selected part of a tubular geometry" + \
@@ -297,7 +303,8 @@ def read_command_line():
     parser = ArgumentParser(description=description, formatter_class=RawDescriptionHelpFormatter)
 
     # Add common arguments
-    add_common_arguments(parser)
+    required = not (input_path is not None and output_path is not None)
+    add_common_arguments(parser, required=required)
 
     # Set region of interest:
     parser.add_argument("-r", "--region-of-interest", type=str, default="manual",
@@ -323,8 +330,11 @@ def read_command_line():
     parser.add_argument("-sl", "--smooth-line", type=str2bool, default=True,
                         help="Smooths centerline if True, anti-smooths if False")
 
-    # Parse
-    args = parser.parse_args()
+    # Parse paths to get default values
+    if required:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(["-i" + input_path, "-o" + output_path])
 
     return dict(input_filepath=args.ifile, smooth=args.smooth,
                 smooth_factor=args.smooth_factor, smooth_factor_line=args.smooth_factor_line,


### PR DESCRIPTION
The demo folder follows the commands that are shown in the tutorial but are here ran from python. This pull request was motivated by a comment in: https://github.com/openjournals/joss-reviews/issues/1065. I belive it is a nice addition to the documentation and provides the user with with a simple way of downloading test data, and seeing python examples, not only commandline.