### PR TITLE
Find diverging centerlines based on line_to_change

### DIFF
--- a/morphman/common/centerline_operations.py
+++ b/morphman/common/centerline_operations.py
@@ -458,7 +458,7 @@ def get_line_to_change(surface, centerline, region_of_interest, method, region_p
 
     # Find diverging ids
     diverging_ids = []
-    main_line = extract_single_line(centerline, 0)
+    main_line = extract_single_line(centerline, cl_id)
     id_start = 0
     for line in diverging_centerlines:
         id_end = min([line.GetNumberOfPoints(), main_line.GetNumberOfPoints()])


### PR DESCRIPTION
* When finding diverging centerlines in the `get_line_to_change()` method, the centerline used to compare against is now the full `line_to_change` instead of the first centerline (`extract_single_line(centerline, 0)`)